### PR TITLE
Make page contents wider

### DIFF
--- a/layouts/pages/categories.ejs
+++ b/layouts/pages/categories.ejs
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', {title: template('landing.viewAll')}) %>
+  <body>
+    <%- include('partials/header', {parentLinks: [], title: template('landing.viewAll')}) %>
+
+    <div id="category-page-upper">
+      <div class="g-upper-body">
+      <%- include('partials/nav') %>
+      </div>
+    </div>
+
+    <div id="category-page" class="g-body">
+      <div class="g-main-content">
+      <% all.forEach((category) => { %>
+        <%- include('partials/childrenList', {kicker: category.prettyName, children: category.children, link: category.path}) %>
+      <% }) %>
+      </div>
+      <script> seeMoreButton() </script>
+      <%- include('partials/footer', { pageType: 'category_index' }) %>
+    </div>
+  </body>
+</html>

--- a/layouts/partials/nav.ejs
+++ b/layouts/partials/nav.ejs
@@ -1,0 +1,52 @@
+<div class="g-upper-body">
+  <%- include('search') %>
+  <div class="g-upper-body-title">
+    <% if (locals.title) { %>
+    <% if (locals.duplicates) { %>
+      <%- include('partials/warning', {message: template('warning.duplicate', locals.duplicates, locals.parentId) }) %>
+    <% } %>
+    <h1 class="headline"><%= title %></h1>
+    <div class="kicker">
+      <div class="attribution">
+          <% if (locals.byline) { %>
+            <p>
+              By <span class="author"><%=locals.byline %></span>.
+            </p>
+          <% } %>
+          <% if (locals.lastUpdatedBy || locals.byline) { %>
+            <p>
+              <% if (locals.lastUpdatedBy) { %>
+                Last edited by <span class="author"><%= lastUpdatedBy %></span><span class="date" data-date="<%= locals.modifiedAt %>"></span>.
+              <% } %>
+              <% if (locals.byline) { %>
+                Created <span class="date" data-date="<%= locals.createdAt %>"></span>.
+              <% } %>
+            </p>
+          <% } %>
+          <script>
+            (function() {
+              $('.date').each(function(i) {
+                const date = $(this)
+                const momentDate = moment(date.data('date'))
+                if (momentDate.isValid()) {
+                  date.html(moment().diff(momentDate, 'years') > 1 ? ` on ${momentDate.format('MMMM D, YYYY')}` : ` ${momentDate.fromNow()}`)
+                  date.attr('title', momentDate.format('MMMM D, YYYY'))
+                }
+              })
+            })()
+          </script>
+        </p>
+      </div>
+
+      <% if (locals.editLink) { %>
+        <div class="tool">
+          <a href="<%- editLink %>" id="edit-button" target="_blank">Edit<i class="fa fa-pencil" aria-hidden="true"></i></a>
+
+        </div>
+      <% } %>
+
+    </div>
+  </div>
+  <% } %>
+
+</div>

--- a/layouts/partials/search.ejs
+++ b/layouts/partials/search.ejs
@@ -1,0 +1,16 @@
+<div class="search-topper">
+  <form method="GET" action="/search" class="search-container">
+    <% const placeholder = template('search.placeholder')%>
+    <% const focus = locals.focus || '' %>
+    <% const msgOnFocus = placeholder || '' %>
+    <input <%= focus %> id="search-box" class="twitter-typeahead" type="text" name="q" value="<%= locals.q %>" placeholder="<%- placeholder %>" />
+    <button class="icon"><i class="fa fa-search"></i></button>
+  </form>
+
+  <% const style = locals.style || 'plaintext' %>
+  <div class="additional-menus <%= style %>">
+    <a href="/categories"><button type="button" class="button btn-<%= style %>"><%- template('landing.viewAll') %></button></a>
+    <%# <a href="#"><button type="button" class="btn-plaintext">Onboarding Guide</button></a>%>
+  </div>
+
+</div>

--- a/layouts/partials/warning.ejs
+++ b/layouts/partials/warning.ejs
@@ -1,0 +1,3 @@
+<div class="warning">
+  Warning: <%- message %>
+</div>

--- a/styles/_custom.scss
+++ b/styles/_custom.scss
@@ -1,5 +1,76 @@
+.g-upper-body-title {
+  @include smalldesktop {
+    margin-left: calc(((100vw - 900px) / 2) - 20px);
+  }
+
+  @media (min-width: 1320px) {
+    margin-left: calc((100vw - 1320px) / 2);
+  }
+}
+
+.g-upper-body {
+  max-width: none;
+
+  @media (min-width: #{$desktop-width}) and (max-width: 1174px) {
+    margin-left: 225px;
+  }
+
+  @media (min-width: 1175px) {
+    margin-left: 270px;
+  }
+
+  .search-topper {
+    max-width: 900px;
+  }
+
+  .kicker {
+    max-width: 900px;
+  }
+}
+
+.g-body .g-left-panel {
+  @include desktop {
+    width: 200px;
+  }
+}
+
 .g-body .g-main-content {
+  max-width: 900px;
+
+  @media (min-width: #{$desktop-width}) and (max-width: 1174px) {
+    margin-left: 225px;
+  }
+
+  @media (min-width: 1175px) {
+    margin-left: 270px;
+  }
+
   p {
     margin-bottom: 20px;
+  }
+}
+
+.g-body .g-footer {
+  max-width: 900px;
+
+  @media (min-width: #{$desktop-width}) and (max-width: 1174px) {
+    margin-left: 225px;
+  }
+
+  @media (min-width: 1175px) {
+    margin-left: 270px;
+  }
+}
+
+#category-page-upper {
+  .g-upper-body {
+    max-width: 900px;
+    margin-left: auto;
+  }
+}
+
+#category-page {
+  .g-main-content {
+    margin-left: 0px;
   }
 }


### PR DESCRIPTION
Main goal of these changes is to make page contents wider.

Official version of library has rather narrow (600px) space for page contents. This is supposedly because it tries to mimic how documents appear in Google Docs. However, in Reaktor Library we want the contents to use more of the available horizontal space.

This required the following changes:

1) `layouts/pages/categories.ejs` had to be customized to add a new CSS div id `category-page-upper`.

2) `layouts/partials/nav.ejs` had to be customized to add a new CSS class `g-upper-body-title`. Also, `partials/search.ejs` and `partials/warning.ejs` had to be copied to custom folder, even though they are identical to official versions. But if they are not copied, the includes in `partials/nav.ejs` break.

3) The actual layout changes are in `styles/_custom.css`. The gist is to give page contents a maximum of 900px space horizontally instead of the default 600px. The rest of the changes are there to ensure that the table of contents (left panel) and the page title (upper body) keep in line with the main contents on all screen widths.